### PR TITLE
fixed stacktrace skip depth

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -133,7 +133,7 @@ func (f *Formatter) Format(e *logrus.Entry) ([]byte, error) {
 		}
 
 		// Extract report location from call stack.
-		c := stack.Caller(4)
+		c := stack.Caller(5)
 
 		lineNumber, _ := strconv.ParseInt(fmt.Sprintf("%d", c), 10, 64)
 


### PR DESCRIPTION
- with the latest logrus, the skip depth must be 5, otherwise it just returns github.com/wattx/statice/manager/vendor/github.com/sirupsen/logrus/exported.go