### PR TITLE
Revert "fixed stacktrace skip depth"

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -133,7 +133,7 @@ func (f *Formatter) Format(e *logrus.Entry) ([]byte, error) {
 		}
 
 		// Extract report location from call stack.
-		c := stack.Caller(5)
+		c := stack.Caller(4)
 
 		lineNumber, _ := strconv.ParseInt(fmt.Sprintf("%d", c), 10, 64)
 


### PR DESCRIPTION
Reverts TV4/logrus-stackdriver-formatter#1

Looks like we need to have a deeper look into this. 