### PR TITLE
Fix stack depth 2nd try

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -3,6 +3,8 @@ package stackdriver
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -59,8 +61,9 @@ type entry struct {
 
 // Formatter implements Stackdriver formatting for logrus.
 type Formatter struct {
-	Service string
-	Version string
+	Service    string
+	Version    string
+	skipRegexp *regexp.Regexp // skip function on the callstack matching this expression
 }
 
 // Option lets you configure the Formatter.
@@ -86,6 +89,7 @@ func NewFormatter(options ...Option) *Formatter {
 	for _, option := range options {
 		option(&fmtr)
 	}
+	fmtr.skipRegexp = regexp.MustCompile(`/logrus\.`)
 	return &fmtr
 }
 
@@ -133,7 +137,16 @@ func (f *Formatter) Format(e *logrus.Entry) ([]byte, error) {
 		}
 
 		// Extract report location from call stack.
-		c := stack.Caller(4)
+		// skip frames until the function is not from logrus package (or give up at 6)
+		skipFrames := 1
+		for ; skipFrames <= 6; skipFrames++ {
+			pc, _, _, _ := runtime.Caller(skipFrames)
+			details := runtime.FuncForPC(pc)
+			if !f.skipRegexp.MatchString(details.Name()) {
+				break
+			}
+		}
+		c := stack.Caller(skipFrames)
 
 		lineNumber, _ := strconv.ParseInt(fmt.Sprintf("%d", c), 10, 64)
 

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const repositoryName = "github.com/wattx"
+
 func TestFormatter(t *testing.T) {
 	skipTimestamp = true
 
@@ -70,19 +72,19 @@ var formatterTests = []struct {
 					"foo": "bar",
 				},
 				"reportLocation": map[string]interface{}{
-					"filePath":     "github.com/TV4/logrus-stackdriver-formatter/formatter_test.go",
-					"lineNumber":   28.0,
-					"functionName": "TestFormatter",
+					"filePath":     repositoryName + "/logrus-stackdriver-formatter/formatter_test.go",
+					"lineNumber":   61.0,
+					"functionName": "glob..func2",
 				},
 			},
 		},
 	},
 	{
 		run: func(logger *logrus.Logger) {
-			logger.
+			l := logger.
 				WithField("foo", "bar").
-				WithError(errors.New("test error")).
-				Error("my log entry")
+				WithError(errors.New("test error"))
+			l.Error("my log entry")
 		},
 		out: map[string]interface{}{
 			"severity": "ERROR",
@@ -96,9 +98,9 @@ var formatterTests = []struct {
 					"foo": "bar",
 				},
 				"reportLocation": map[string]interface{}{
-					"filePath":     "github.com/TV4/logrus-stackdriver-formatter/formatter_test.go",
-					"lineNumber":   28.0,
-					"functionName": "TestFormatter",
+					"filePath":     repositoryName + "/logrus-stackdriver-formatter/formatter_test.go",
+					"lineNumber":   87.0,
+					"functionName": "glob..func3",
 				},
 			},
 		},
@@ -129,9 +131,9 @@ var formatterTests = []struct {
 					"method": "GET",
 				},
 				"reportLocation": map[string]interface{}{
-					"filePath":     "github.com/TV4/logrus-stackdriver-formatter/formatter_test.go",
-					"lineNumber":   28.0,
-					"functionName": "TestFormatter",
+					"filePath":     repositoryName + "/logrus-stackdriver-formatter/formatter_test.go",
+					"lineNumber":   117.0,
+					"functionName": "glob..func4",
 				},
 			},
 		},

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const repositoryName = "github.com/wattx"
+const repositoryName = "github.com/TV4"
 
 func TestFormatter(t *testing.T) {
 	skipTimestamp = true


### PR DESCRIPTION
Hey again, I prepared another PR, this time I also adapted the test (sorry for the last PR). To explain a bit more: you are using a fixed number of skip frames to identify the function calling log.Error or log.Errorf, for example. The problem is, that this number is not constant. For example Errorf will first format and then call Error. My solution goes up the stack frame by frame, and checks wether the package of the current frame's function is logrus. It stops at the first package that is not logrus.

You can even see that the current test is testing the wrong stuff, as all expected line numbers are 28. This is clearly not the case, as Error is called on multiple different lines.