### PR TITLE
Fix stack caller for error reporting

### DIFF
--- a/formatter_test.go
+++ b/formatter_test.go
@@ -71,8 +71,8 @@ var formatterTests = []struct {
 				},
 				"reportLocation": map[string]interface{}{
 					"filePath":     "github.com/TV4/logrus-stackdriver-formatter/formatter_test.go",
-					"lineNumber":   28.0,
-					"functionName": "TestFormatter",
+					"lineNumber":   59.0,
+					"functionName": "glob..func2",
 				},
 			},
 		},
@@ -97,8 +97,8 @@ var formatterTests = []struct {
 				},
 				"reportLocation": map[string]interface{}{
 					"filePath":     "github.com/TV4/logrus-stackdriver-formatter/formatter_test.go",
-					"lineNumber":   28.0,
-					"functionName": "TestFormatter",
+					"lineNumber":   85.0,
+					"functionName": "glob..func3",
 				},
 			},
 		},
@@ -130,8 +130,8 @@ var formatterTests = []struct {
 				},
 				"reportLocation": map[string]interface{}{
 					"filePath":     "github.com/TV4/logrus-stackdriver-formatter/formatter_test.go",
-					"lineNumber":   28.0,
-					"functionName": "TestFormatter",
+					"lineNumber":   115.0,
+					"functionName": "glob..func4",
 				},
 			},
 		},


### PR DESCRIPTION
Rather than using a hardcoded stack skip index, this change walks up the stack
to find the first caller in a package outside of a skip list.

By default, only logrus is skipped. However, this can be overridden with
stackdriver.WithStackSkip("package").

This is useful for skipping packages that might be wrapping logrus. It
also supports vendoring.

It's very similar to #3 except it doesn't rely on regexp.

Updated the tests which had incorrect line number and functions.